### PR TITLE
Remove redundant spec.name from the clusterproperty API, the metadata.name is the actual name of the clusterproperty.

### DIFF
--- a/clusterproperty/api/v1alpha1/clusterproperty_types.go
+++ b/clusterproperty/api/v1alpha1/clusterproperty_types.go
@@ -28,9 +28,6 @@ type ClusterPropertySpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// ClusterProperty Name
-	Name string `json:"name,omitempty"`
-
 	// ClusterProperty value
 	// +kubebuilder:validation:Maxlength=128000
 	// +kubebuilder:validation:MinLength=1

--- a/clusterproperty/config/crd/bases/about.k8s.io_clusterproperties.yaml
+++ b/clusterproperty/config/crd/bases/about.k8s.io_clusterproperties.yaml
@@ -42,9 +42,6 @@ spec:
           spec:
             description: ClusterPropertySpec defines the desired state of ClusterProperty
             properties:
-              name:
-                description: ClusterProperty Name
-                type: string
               value:
                 description: ClusterProperty value
                 minLength: 1


### PR DESCRIPTION
Closes https://github.com/kubernetes-sigs/about-api/issues/7

Signed-off-by: Mike Ng <ming@redhat.com>