### PR TITLE
Have prowbot add sig label to PRs

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,3 +4,6 @@ approvers:
   - lauralorenz
   - jeremyot
   - pmorie
+
+labels:
+  - sig/multicluster


### PR DESCRIPTION
Per slack thread https://kubernetes.slack.com/archives/C01672LSZL0/p1756921680659559?thread_ts=1756915946.247499&cid=C01672LSZL0

Example: https://github.com/kubernetes/kubernetes/blob/master/OWNERS#L32-L36
Docs: https://www.kubernetes.dev/docs/guide/owners/#owners