### PR TITLE
Add multicluster category to ClusterProperty CRD

### DIFF
--- a/api/v1alpha1/clusterproperty_types.go
+++ b/api/v1alpha1/clusterproperty_types.go
@@ -41,7 +41,7 @@ type ClusterPropertyStatus struct {
 //+genclient:nonNamespaced
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:resource:scope=Cluster
+//+kubebuilder:resource:scope=Cluster,categories=multicluster
 
 // ClusterProperty is a resource provides a way to store identification related,
 // cluster scoped information for multi-cluster tools while creating flexibility

--- a/api/v1beta1/clusterproperty_types.go
+++ b/api/v1beta1/clusterproperty_types.go
@@ -44,7 +44,7 @@ type ClusterPropertyStatus struct {
 //+genclient:nonNamespaced
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:resource:scope=Cluster
+//+kubebuilder:resource:scope=Cluster,categories=multicluster
 
 // ClusterProperty is a resource provides a way to store identification related,
 // cluster scoped information for multi-cluster tools while creating flexibility

--- a/config/crd/about.k8s.io_clusterproperties.yaml
+++ b/config/crd/about.k8s.io_clusterproperties.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: about.k8s.io
   names:
+    categories:
+    - multicluster
     kind: ClusterProperty
     listKind: ClusterPropertyList
     plural: clusterproperties

--- a/config/crd/bases/about.k8s.io_clusterproperties.yaml
+++ b/config/crd/bases/about.k8s.io_clusterproperties.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: about.k8s.io
   names:
+    categories:
+    - multicluster
     kind: ClusterProperty
     listKind: ClusterPropertyList
     plural: clusterproperties


### PR DESCRIPTION
## Summary

Add the `multicluster` category to the About API CRD.

## Background

Following [this discussion](https://github.com/kubernetes-sigs/cluster-inventory-api/pull/80#issuecomment-5071886576), SIG Multicluster CRDs should use a common category. This allows users to list these resources together with `kubectl get multicluster`.
