### PR TITLE
Point the CRD generator at the file kustomize actually builds

### DIFF
--- a/config/crd/bases/about.k8s.io_clusterproperties.yaml
+++ b/config/crd/bases/about.k8s.io_clusterproperties.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: clusterproperties.about.k8s.io
 spec:
   group: about.k8s.io
@@ -16,6 +16,56 @@ spec:
     singular: clusterproperty
   scope: Cluster
   versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.value
+      name: value
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ClusterProperty is a resource provides a way to store identification related,
+          cluster scoped information for multi-cluster tools while creating flexibility
+          for implementations.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterPropertySpec defines the desired state of ClusterProperty.
+            properties:
+              value:
+                description: ClusterProperty value
+                minLength: 1
+                type: string
+            required:
+            - value
+            type: object
+          status:
+            description: ClusterPropertyStatus defines the observed state of ClusterProperty.
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
   - additionalPrinterColumns:
     - jsonPath: .spec.value
       name: value

--- a/hack/update-crdgen.sh
+++ b/hack/update-crdgen.sh
@@ -7,4 +7,4 @@ set -o pipefail
 echo "Generating with controller-gen"
 
 # Unify the crds used by helm chart and the installation scripts
-"$(go -C tools tool -n sigs.k8s.io/controller-tools/cmd/controller-gen)" crd paths=./api/... output:crd:dir=./config/crd/
+"$(go -C tools tool -n sigs.k8s.io/controller-tools/cmd/controller-gen)" crd paths=./api/... output:crd:dir=./config/crd/bases/


### PR DESCRIPTION
update-crdgen.sh wrote to config/crd/, but config/crd/kustomization.yaml, what make install builds from, only reads config/crd/bases/. That copy never got regenerated, so it only served v1beta1 and was missing v1alpha1 entirely.

Applying the repo's own v1alpha1 sample manifest, config/samples/about_v1alpha1_clusterproperty.yaml, against a cluster with the CRD installed the old way fails with no matches for kind ClusterProperty in version about.k8s.io/v1alpha1. The two API versions have byte identical schemas, so this is not a conversion webhook gap, just a stale generated file.

Tested: fixed the generator path, ran make manifests for real, then verified against a live kind cluster: installed the regenerated CRD with kubectl apply -k config/crd, confirmed kubectl get crd ... now lists both v1alpha1 and v1beta1 as served versions, and confirmed the sample manifest applies successfully where it previously failed. go build, go vet and go test are clean.

Left the now unused top level config/crd/about.k8s.io_clusterproperties.yaml file alone rather than deleting it. Given issue #28 and PR #35's history of cleaning up duplicate CRD files here, I'd rather a maintainer confirm that removal separately than fold it into this fix.

/kind bug
/sig multicluster