### PR TITLE
Remove dead RSS feed link from SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,6 @@
 
 Join the [kubernetes-security-announce] group for security and vulnerability announcements.
 
-You can also subscribe to an RSS feed of the above using [this link][kubernetes-security-announce-rss].
-
 ## Reporting a Vulnerability
 
 Instructions for reporting a vulnerability can be found on the
@@ -17,6 +15,5 @@ Information about supported Kubernetes versions can be found on the
 [Kubernetes version and version skew support policy] page on the Kubernetes website.
 
 [kubernetes-security-announce]: https://groups.google.com/forum/#!forum/kubernetes-security-announce
-[kubernetes-security-announce-rss]: https://groups.google.com/forum/feed/kubernetes-security-announce/msgs/rss_v2_0.xml?num=50
 [Kubernetes version and version skew support policy]: https://kubernetes.io/docs/setup/release/version-skew-policy/#supported-versions
 [Kubernetes Security and Disclosure Information]: https://kubernetes.io/docs/reference/issues-security/security/#report-a-vulnerability


### PR DESCRIPTION
This repository has no PR template, so this is a plain description.

`SECURITY.md`'s RSS-feed link 404s: Google Groups retired RSS feeds platform-wide, and there's no replacement URL. Confirmed by checking the same feed URL pattern against other unrelated Google Groups too, all dead. The current standard kubernetes-sigs SECURITY.md template (checked against kubernetes-sigs/kueue's live file) has already dropped this line, so this repo's copy is just stale.

Removed the sentence and the dead reference link, matching the current template exactly.

Doc-only change.
